### PR TITLE
Updates to pretty printing output formatting

### DIFF
--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -172,7 +172,8 @@ toIntermediate
       IList sw sz hd rs Nothing
     gather sw hd rs (SAtom a) sz =
       IList sw (sz `concatSize` aSize) hd rs (Just aStr)
-        where aSize = Size (T.length aStr) (T.length aStr)
+        where aSize = Size aLen aLen
+              aLen = T.length aStr + 2 -- 2 for the ". " between the pair
               aStr = printAtom a
     gather sw hd rs (SCons x xs) sz =
       gather sw hd (rs Seq.|> x') xs (sz `concatSize` sizeOf x')

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -412,7 +412,7 @@ indentPrintSExpr' maxAmt pr@SExprPrinter { .. } = B.toLazyText . pp 0 . toInterm
               let nextInd = ind + indentAmount + 1 -- 1 for (
               in indentAllS nextInd (fmap (pp nextInd) values)
             Align ->
-              let nextInd = ind + headWidth + 1
+              let nextInd = ind + headWidth + 1 + 1 -- 1 for (, 1 for ' ' below
               in B.singleton ' ' <>
                  indentSubsequentS nextInd (fmap (pp nextInd) values)
         body

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -407,20 +407,21 @@ indentPrintSExpr' maxAmt pr@SExprPrinter { .. } = B.toLazyText . pp 0 . toInterm
                   t  = unwordsS (fmap (pp (ind+1)) l)
                   ts = indentAllS (ind + indentAmount)
                        (fmap (pp (ind + indentAmount)) ls)
-              in t <> ts
+              in B.singleton ' ' <> t <> ts
             Swing ->
-              indentAllS (ind + indentAmount)
-                (fmap (pp (ind + indentAmount)) values)
+              let nextInd = ind + indentAmount
+              in indentAllS nextInd (fmap (pp nextInd) values)
             Align ->
-              indentSubsequentS (ind + headWidth + 1)
-                (fmap (pp (ind + headWidth + 1)) values)
+              let nextInd = ind + headWidth + 1
+              in B.singleton ' ' <>
+                 indentSubsequentS nextInd (fmap (pp nextInd) values)
         body
           -- if there's nothing here, then we don't have anything to
           -- indent
           | length values == 0 = mempty
           -- if we can't fit the whole next s-expression on the same
           -- line, then we use the indented form
-          | sizeSum sz + ind > maxAmt = B.singleton ' ' <> indented
+          | sizeSum sz + ind > maxAmt = indented
           | otherwise =
             -- otherwise we print the whole thing on one line!
             B.singleton ' ' <> unwordsS (fmap (pp (ind + 1)) values)

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -409,7 +409,7 @@ indentPrintSExpr' maxAmt pr@SExprPrinter { .. } = B.toLazyText . pp 0 . toInterm
                        (fmap (pp (ind + indentAmount)) ls)
               in B.singleton ' ' <> t <> ts
             Swing ->
-              let nextInd = ind + indentAmount
+              let nextInd = ind + indentAmount + 1 -- 1 for (
               in indentAllS nextInd (fmap (pp nextInd) values)
             Align ->
               let nextInd = ind + headWidth + 1

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -36,8 +36,9 @@ import           Data.SCargot.Repr
 
 -- | The 'Indent' type is used to determine how to indent subsequent
 --   s-expressions in a list, after printing the head of the list.  This only
---   applies if the entire list cannot be printed within the allowable maxWidth;
---   a sub-maxWidth printing will not add newlines or indentation.
+--   applies if the entire list cannot be printed within the allowable
+--   'SExprPrinter.maxWidth'; a sub-maxWidth printing will not add newlines or
+--   indentation.
 data Indent
   = Swing -- ^ A 'Swing' indent will indent subsequent exprs some fixed
           --   amount more than the current line.
@@ -46,6 +47,9 @@ data Indent
           --   >   bar
           --   >   baz
           --   >   quux)
+          --
+          -- Any 'SExprPrinter.indentAmount' applies relative to the entry at the
+          -- head of the list; in the above example, the indentAmount is 1.
   | SwingAfter Int -- ^ A 'SwingAfter' @n@ indent will try to print the
                    --   first @n@ expressions after the head on the same
                    --   line as the head, and all after will be swung.
@@ -54,9 +58,13 @@ data Indent
                    --   > (foo bar
                    --   >   baz
                    --   >   quux)
-  | Align -- ^ An 'Align' indent will print the first expression after
-          --   the head on the same line, and subsequent expressions will
-          --   be aligned with that one.
+                   --
+                   -- The 'SExprPrinter.indentAmount' is handled in the same way
+                   -- as for the 'Swing' setting.
+  | Align -- ^ An 'Align' indent will print the first expression after the head
+          -- on the same line, and subsequent expressions will be aligned with
+          -- that one.  Note that this ignores any 'SExprPrinter.indentAmount'
+          -- specified for the printer.
           --
           --   > (foo bar
           --   >      baz
@@ -77,14 +85,15 @@ data SExprPrinter atom carrier = SExprPrinter
       -- ^ How to indent subsequent expressions, as determined by
       --   the head of the list.
   , indentAmount :: Int
-      -- ^ How much to indent after a swung indentation.
+      -- ^ How much to indent after a swung indentation, relative to the *head*
+      -- element.
   , maxWidth     :: Maybe Int
-      -- ^ The maximum width (if any) If this is 'None' then the
-      --   resulting s-expression might be printed on one line (if
-      --   'indentPrint' is 'False') and might be pretty-printed in
-      --   the most naive way possible (if 'indentPrint' is 'True').
+      -- ^ The maximum width (if any) If this is 'None' then the resulting
+      --   s-expression might be printed on one line (if
+      --   'SExprPrinter.indentPrint' is 'False') and might be pretty-printed in
+      --   the most naive way possible (if 'SExprPrinter.indentPrint' is 'True').
   , indentPrint :: Bool
-      -- ^ Whether to indent or not. This has been retrofitted onto
+      -- ^ Whether to indent or not.
   }
 
 

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -35,7 +35,9 @@ import           Data.SCargot.Repr
 
 
 -- | The 'Indent' type is used to determine how to indent subsequent
---   s-expressions in a list, after printing the head of the list.
+--   s-expressions in a list, after printing the head of the list.  This only
+--   applies if the entire list cannot be printed within the allowable maxWidth;
+--   a sub-maxWidth printing will not add newlines or indentation.
 data Indent
   = Swing -- ^ A 'Swing' indent will indent subsequent exprs some fixed
           --   amount more than the current line.

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -355,7 +355,9 @@ unwordsS s = case Seq.viewl s of
 -- Indents every line n spaces, and adds a newline to the beginning
 -- used in swung indents
 indentAllS :: Int -> Seq.Seq B.Builder -> B.Builder
-indentAllS n = ("\n" <>) . joinLinesS . fmap (indent n)
+indentAllS n s = if Seq.null s
+                 then ""
+                 else ("\n" <>) $ joinLinesS $ fmap (indent n) s
 
 -- Indents every line but the first by some amount
 -- used in aligned indents
@@ -404,9 +406,9 @@ indentPrintSExpr' maxAmt pr@SExprPrinter { .. } = B.toLazyText . pp 0 . toInterm
           case i of
             SwingAfter n ->
               let (l, ls) = Seq.splitAt n values
-                  t  = unwordsS (fmap (pp (ind+1)) l)
-                  ts = indentAllS (ind + indentAmount)
-                       (fmap (pp (ind + indentAmount)) ls)
+                  t  = unwordsS (fmap (pp (ind+1+1)) l) -- 1 for (, 1 for ' '
+                  nextInd = ind + indentAmount + 1 -- 1 for (
+                  ts = indentAllS nextInd (fmap (pp nextInd) ls)
               in B.singleton ' ' <> t <> ts
             Swing ->
               let nextInd = ind + indentAmount + 1 -- 1 for (

--- a/Data/SCargot/Print.hs
+++ b/Data/SCargot/Print.hs
@@ -233,7 +233,7 @@ unboundIndentPrintSExpr spec = finalize . go . toIntermediate spec
             in handleTail rest butLast
 
     doIndent :: B.Builder -> B.Builder
-    doIndent = doIndentOf (indentAmount spec)
+    doIndent = doIndentOf (indentAmount spec + 1) -- 1 for '('
 
     doIndentOf :: Int -> B.Builder -> B.Builder
     doIndentOf n b = B.fromText (T.replicate n " ") <> b
@@ -246,7 +246,9 @@ unboundIndentPrintSExpr spec = finalize . go . toIntermediate spec
     handleTail :: Maybe Text -> Seq.Seq B.Builder -> Seq.Seq B.Builder
     handleTail Nothing = insertCloseParen
     handleTail (Just t) =
-      (Seq.|> (B.fromString " . " <> B.fromText t <> B.singleton ')'))
+      let txtInd = B.fromText $ T.replicate (indentAmount spec) " "
+          sep = B.fromString " . "
+      in (Seq.|> (txtInd <> sep <> B.fromText t <> B.singleton ')'))
 
     insertCloseParen :: Seq.Seq B.Builder -> Seq.Seq B.Builder
     insertCloseParen s = case Seq.viewr s of

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -333,21 +333,21 @@ main = do
                 , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
                   pprintIt l2
                 , TestLabel "pretty print list of 2 pairs" $
-                  "((hi . hallo)\n world\n . welt)" ~=?
+                  "((hi . hallo)\n  world\n  . welt)" ~=?
                   pprintIt l2p
                 , TestLabel "pretty print list of 3 starting in a pair" $
                   -- pairs count as a single element
-                  "((hi . world)\n hallo\n welt)" ~=?
+                  "((hi . world)\n  hallo\n  welt)" ~=?
                   pprintIt l3sp
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi world hallo . welt)" ~=?
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
                   pprintIt l3
-                , TestLabel "pretty print pair of list of 4" $ "(hi\n (world and people)\n hallo\n welt\n und\n leute)" ~=?
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n  (world and people)\n  hallo\n  welt\n  und\n  leute)" ~=?
                   pprintIt linl
                 , TestLabel "pretty print list of 5 pairs" $
-                  "((hi . world)\n (hallo . welt)\n (bonjour . monde)\n (hola . mundo)\n ciao\n . mundo)" ~=?
+                  "((hi . world)\n  (hallo . welt)\n  (bonjour . monde)\n  (hola . mundo)\n  ciao\n  . mundo)" ~=?
                   pprintIt l5p
                 ]
 

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -292,6 +292,36 @@ main = do
                   pprintIt l5p
                 ]
 
+              , TestLabel "pretty print width 400" $
+                let pprintIt = pprintSExpr 400 Swing in TestList
+                [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
+                , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
+                , TestLabel "pretty print pair" $ "(hi . world)" ~=?
+                  pprintIt pair
+                , TestLabel "pretty print list of 1" $ "(hi)" ~=?
+                  pprintIt l1
+                , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
+                  pprintIt l2
+                , TestLabel "pretty print list of 2 pairs" $
+                  -- No Swing if it fits on a line
+                  "((hi . hallo) world . welt)" ~=?
+                  pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world) hallo welt)" ~=?
+                  pprintIt l3sp
+                , TestLabel "pretty print list of 3 ending in a pair" $
+                  "(hi world hallo . welt)" ~=?
+                  pprintIt l3ep
+                , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
+                  pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $ "(hi (world and people) hallo welt und leute)" ~=?
+                  pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world) (hallo . welt) (bonjour . monde) (hola . mundo) ciao . mundo)" ~=?
+                  pprintIt l5p
+                ]
+
               , TestLabel "unconstrained print" $
                 let pprintIt = ucPrintSExpr Swing in TestList
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -118,7 +118,7 @@ main = do
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
                   pprintIt l3
-                , TestLabel "pretty print pair of list of 4" $ "(hi \n (world and people)\n hallo\n welt\n und\n leute)" ~=?
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n (world and people)\n hallo\n welt\n und\n leute)" ~=?
                   pprintIt linl
                 ]
 
@@ -133,14 +133,14 @@ main = do
                 , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
                   pprintIt l2
                 , TestLabel "pretty print list of 2 pairs" $
-                  "((hi . hallo) \n world . welt)" ~=?
+                  "((hi . hallo)\n world . welt)" ~=?
                   pprintIt l2p
                 , TestLabel "pretty print list of 3 ending in a pair" $
-                  "(hi \n world\n hallo . welt)" ~=?
+                  "(hi\n world\n hallo . welt)" ~=?
                   pprintIt l3ep
-                , TestLabel "pretty print list of 3" $ "(hi \n world\n hallo)" ~=?
+                , TestLabel "pretty print list of 3" $ "(hi\n world\n hallo)" ~=?
                   pprintIt l3
-                , TestLabel "pretty print pair of list of 4" $ "(hi \n (world \n  and\n  people)\n hallo\n welt\n und\n leute)" ~=?
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n (world\n  and\n  people)\n hallo\n welt\n und\n leute)" ~=?
                   pprintIt linl
                 ]
 

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -195,6 +195,40 @@ main = do
                   pprintIt l5p
                 ]
 
+              , TestLabel "pretty print width 10 indent 5" $
+                let pprintIt = encodeOne (setIndentStrategy (const Swing) $
+                                          setIndentAmount 5 $
+                                          setMaxWidth 10 $
+                                          basicPrint printAtom)
+                in TestList
+                [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
+                , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
+                , TestLabel "pretty print pair" $ "(hi . world)" ~=?
+                  pprintIt pair
+                , TestLabel "pretty print list of 1" $ "(hi)" ~=?
+                  pprintIt l1
+                , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
+                  pprintIt l2
+                , TestLabel "pretty print list of 2 pairs" $
+                  "((hi . hallo)\n      world . welt)" ~=?
+                  pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world)\n      hallo\n      welt)" ~=?
+                  pprintIt l3sp
+                , TestLabel "pretty print list of 3 ending in a pair" $
+                  "(hi\n      world\n      hallo . welt)" ~=?
+                  pprintIt l3ep
+                , TestLabel "pretty print list of 3" $
+                  "(hi\n      world\n      hallo)" ~=?
+                  pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n      (world\n            and\n            people)\n      hallo\n      welt\n      und\n      leute)" ~=?
+                  pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world)\n      (hallo . welt)\n      (bonjour . monde)\n      (hola . mundo)\n      ciao . mundo)" ~=?
+                  pprintIt l5p
+                ]
+
               , TestLabel "pretty print width 10 swing-after 3" $
                 let pprintIt = pprintSExpr 10 (SwingAfter 3) in TestList
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -24,34 +24,58 @@ main = do
                                                 , "test/med2-sample.sexp"
                                                 , "test/big-sample.sexp"
                                                 ]
-  counts <- runTestTT $ TestList
+  counts <- runTestTT $ TestList $
+            let
+              -- l2p = list of 2 pairs
+              l2p = (SCons
+                      (SCons
+                        (SAtom (AIdent "hi"))
+                        (SAtom (AIdent "hallo")))
+                      (SCons
+                        (SAtom (AIdent "world"))
+                        (SAtom (AIdent "welt"))))
+              -- l3ep = list of 3 ending in a pair
+              l3ep = (SCons
+                       (SAtom (AIdent "hi"))
+                       (SCons
+                         (SAtom (AIdent "world"))
+                         (SCons
+                           (SAtom (AIdent "hallo"))
+                           (SAtom (AIdent "welt")))))
+              -- l3 = list of 3
+              l3 = (SCons
+                     (SAtom (AIdent "hi"))
+                     (SCons
+                       (SAtom (AIdent "world"))
+                       (SCons
+                         (SAtom (AIdent "hallo"))
+                         SNil)))
+              -- l2 = list of 2
+              l2 = (SCons
+                     (SAtom (AIdent "hi"))
+                     (SCons
+                       (SAtom (AIdent "world"))
+                       SNil))
+              -- l1 = list of 1
+              l1 = (SCons (SAtom (AIdent "hi")) SNil)
+              pair = (SCons (SAtom (AIdent "hi")) (SAtom (AIdent "world")))
+            in
             [ TestLabel "basic checks" $ TestList
               [ TestLabel "flat print" $ TestList
                 [ TestLabel "flatprint SNil" $ "()" ~=? printSExpr SNil
                 , TestLabel "flatprint SAtom" $ "hi" ~=? printSExpr (SAtom (AIdent "hi"))
                 , TestLabel "flatprint pair" $ "(hi . world)" ~=?
-                  printSExpr (SCons (SAtom (AIdent "hi")) (SAtom (AIdent "world")))
+                  printSExpr pair
                 , TestLabel "flatprint list of 1" $ "(hi)" ~=?
-                  printSExpr (SCons (SAtom (AIdent "hi")) SNil)
+                  printSExpr l1
                 , TestLabel "flatprint list of 2" $ "(hi world)" ~=?
-                  printSExpr (SCons (SAtom (AIdent "hi"))
-                                    (SCons (SAtom (AIdent "world"))
-                                           SNil))
+                  printSExpr l2
                 , TestLabel "flatprint list of 2 pairs" $ "((hi . hallo) world . welt)" ~=?
-                  printSExpr (SCons (SCons (SAtom (AIdent "hi"))
-                                           (SAtom (AIdent "hallo")))
-                                    (SCons (SAtom (AIdent "world"))
-                                           (SAtom (AIdent "welt"))))
+                  printSExpr l2p
                 , TestLabel "flatprint list of 3 ending in a pair" $ "(hi world hallo . welt)" ~=?
-                  printSExpr (SCons (SAtom (AIdent "hi"))
-                                    (SCons (SAtom (AIdent "world"))
-                                           (SCons (SAtom (AIdent "hallo"))
-                                                  (SAtom (AIdent "welt")))))
+                  printSExpr l3ep
                 , TestLabel "flatprint list of 3" $ "(hi world hallo)" ~=?
-                  printSExpr (SCons (SAtom (AIdent "hi"))
-                                    (SCons (SAtom (AIdent "world"))
-                                           (SCons (SAtom (AIdent "hallo"))
-                                                  SNil)))
+                  printSExpr l3
                 ]
 
               , TestLabel "pretty print" $
@@ -59,30 +83,19 @@ main = do
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
                 , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
                 , TestLabel "pretty print pair" $ "(hi . world)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi")) (SAtom (AIdent "world")))
+                  pprintIt pair
                 , TestLabel "pretty print list of 1" $ "(hi)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi")) SNil)
+                  pprintIt l1
                 , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi"))
-                                  (SCons (SAtom (AIdent "world"))
-                                         SNil))
+                  pprintIt l2
                 , TestLabel "pretty print list of 2 pairs" $
                   "((hi . hallo) world . welt)" ~=?
-                  pprintIt (SCons (SCons (SAtom (AIdent "hi"))
-                                         (SAtom (AIdent "hallo")))
-                                  (SCons (SAtom (AIdent "world"))
-                                         (SAtom (AIdent "welt"))))
+                  pprintIt l2p
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi world hallo . welt)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi"))
-                                  (SCons (SAtom (AIdent "world"))
-                                         (SCons (SAtom (AIdent "hallo"))
-                                                (SAtom (AIdent "welt")))))
+                  pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi"))
-                                  (SCons (SAtom (AIdent "world"))
-                                         (SCons (SAtom (AIdent "hallo"))
-                                                SNil)))
+                  pprintIt l3
                 ]
 
               , TestLabel "unconstrained print" $
@@ -90,30 +103,19 @@ main = do
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
                 , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
                 , TestLabel "pretty print pair" $ "(hi . world)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi")) (SAtom (AIdent "world")))
+                  pprintIt pair
                 , TestLabel "pretty print list of 1" $ "(hi)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi")) SNil)
+                  pprintIt l1
                 , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi"))
-                                  (SCons (SAtom (AIdent "world"))
-                                         SNil))
+                  pprintIt l2
                 , TestLabel "pretty print list of 2 pairs" $
                   "((hi . hallo)\n world\n . welt)" ~=?
-                  pprintIt (SCons (SCons (SAtom (AIdent "hi"))
-                                         (SAtom (AIdent "hallo")))
-                                  (SCons (SAtom (AIdent "world"))
-                                         (SAtom (AIdent "welt"))))
+                  pprintIt l2p
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi world hallo . welt)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi"))
-                                  (SCons (SAtom (AIdent "world"))
-                                         (SCons (SAtom (AIdent "hallo"))
-                                                (SAtom (AIdent "welt")))))
+                  pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
-                  pprintIt (SCons (SAtom (AIdent "hi"))
-                                  (SCons (SAtom (AIdent "world"))
-                                         (SCons (SAtom (AIdent "hallo"))
-                                                SNil)))
+                  pprintIt l3
                 ]
 
               ]

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -144,6 +144,28 @@ main = do
                   pprintIt linl
                 ]
 
+              , TestLabel "pretty print width 10 aligned" $
+                let pprintIt = pprintSExpr 10 Align in TestList
+                [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
+                , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
+                , TestLabel "pretty print pair" $ "(hi . world)" ~=?
+                  pprintIt pair
+                , TestLabel "pretty print list of 1" $ "(hi)" ~=?
+                  pprintIt l1
+                , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
+                  pprintIt l2
+                , TestLabel "pretty print list of 2 pairs" $
+                  "((hi . hallo) world . welt)" ~=?
+                  pprintIt l2p
+                , TestLabel "pretty print list of 3 ending in a pair" $
+                  "(hi world\n    hallo . welt)" ~=?
+                  pprintIt l3ep
+                , TestLabel "pretty print list of 3" $ "(hi world\n    hallo)" ~=?
+                  pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $ "(hi (world and\n           people)\n    hallo\n    welt\n    und\n    leute)" ~=?
+                  pprintIt linl
+                ]
+
               , TestLabel "unconstrained print" $
                 let pprintIt = ucPrintSExpr Swing in TestList
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -59,6 +59,26 @@ main = do
               -- l1 = list of 1
               l1 = (SCons (SAtom (AIdent "hi")) SNil)
               pair = (SCons (SAtom (AIdent "hi")) (SAtom (AIdent "world")))
+              -- linl = list within a list
+              linl = (SCons
+                         (SAtom (AIdent "hi"))
+                         (SCons
+                           (SCons
+                            (SAtom (AIdent "world"))
+                            (SCons
+                              (SAtom (AIdent "and"))
+                              (SCons
+                                (SAtom (AIdent "people"))
+                                SNil)))
+                           (SCons
+                            (SAtom (AIdent "hallo"))
+                            (SCons
+                             (SAtom (AIdent "welt"))
+                             (SCons
+                               (SAtom (AIdent "und"))
+                               (SCons
+                                 (SAtom (AIdent "leute"))
+                                 SNil))))))
             in
             [ TestLabel "basic checks" $ TestList
               [ TestLabel "flat print" $ TestList
@@ -76,6 +96,8 @@ main = do
                   printSExpr l3ep
                 , TestLabel "flatprint list of 3" $ "(hi world hallo)" ~=?
                   printSExpr l3
+                , TestLabel "flatprint pair of list of 4" $ "(hi (world and people) hallo welt und leute)" ~=?
+                  printSExpr linl
                 ]
 
               , TestLabel "pretty print width 40" $
@@ -96,6 +118,8 @@ main = do
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
                   pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $ "(hi \n (world and people)\n hallo\n welt\n und\n leute)" ~=?
+                  pprintIt linl
                 ]
 
               , TestLabel "pretty print width 10" $
@@ -116,6 +140,8 @@ main = do
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi \n world\n hallo)" ~=?
                   pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $ "(hi \n (world \n  and\n  people)\n hallo\n welt\n und\n leute)" ~=?
+                  pprintIt linl
                 ]
 
               , TestLabel "unconstrained print" $
@@ -136,6 +162,8 @@ main = do
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
                   pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n (world and people)\n hallo\n welt\n und\n leute)" ~=?
+                  pprintIt linl
                 ]
 
               ]

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -144,6 +144,32 @@ main = do
                   pprintIt linl
                 ]
 
+              , TestLabel "pretty print width 10 swing-after 3" $
+                let pprintIt = pprintSExpr 10 (SwingAfter 3) in TestList
+                [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
+                , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
+                , TestLabel "pretty print pair" $ "(hi . world)" ~=?
+                  pprintIt pair
+                , TestLabel "pretty print list of 1" $ "(hi)" ~=?
+                  pprintIt l1
+                , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
+                  pprintIt l2
+                , TestLabel "pretty print list of 2 pairs" $
+                  -- pairs are not split internally
+                  "((hi . hallo) world . welt)" ~=?
+                  pprintIt l2p
+                , TestLabel "pretty print list of 3 ending in a pair" $
+                  -- pairs are not split internally
+                  "(hi world hallo . welt)" ~=?
+                  pprintIt l3ep
+                , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
+                  pprintIt l3
+                , TestLabel "pretty print pair of list of 4" $
+                  -- atom list pair\n ...
+                  "(hi (world and people) hallo welt\n  und\n  leute)" ~=?
+                  pprintIt linl
+                ]
+
               , TestLabel "pretty print width 10 aligned" $
                 let pprintIt = pprintSExpr 10 Align in TestList
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -118,7 +118,7 @@ main = do
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
                   pprintIt l3
-                , TestLabel "pretty print pair of list of 4" $ "(hi\n (world and people)\n hallo\n welt\n und\n leute)" ~=?
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n  (world and people)\n  hallo\n  welt\n  und\n  leute)" ~=?
                   pprintIt linl
                 ]
 
@@ -133,14 +133,14 @@ main = do
                 , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
                   pprintIt l2
                 , TestLabel "pretty print list of 2 pairs" $
-                  "((hi . hallo)\n world . welt)" ~=?
+                  "((hi . hallo)\n  world . welt)" ~=?
                   pprintIt l2p
                 , TestLabel "pretty print list of 3 ending in a pair" $
-                  "(hi\n world\n hallo . welt)" ~=?
+                  "(hi\n  world\n  hallo . welt)" ~=?
                   pprintIt l3ep
-                , TestLabel "pretty print list of 3" $ "(hi\n world\n hallo)" ~=?
+                , TestLabel "pretty print list of 3" $ "(hi\n  world\n  hallo)" ~=?
                   pprintIt l3
-                , TestLabel "pretty print pair of list of 4" $ "(hi\n (world\n  and\n  people)\n hallo\n welt\n und\n leute)" ~=?
+                , TestLabel "pretty print pair of list of 4" $ "(hi\n  (world\n    and\n    people)\n  hallo\n  welt\n  und\n  leute)" ~=?
                   pprintIt linl
                 ]
 

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -78,7 +78,7 @@ main = do
                   printSExpr l3
                 ]
 
-              , TestLabel "pretty print" $
+              , TestLabel "pretty print width 40" $
                 let pprintIt = pprintSExpr 40 Swing in TestList
                 [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
                 , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
@@ -95,6 +95,26 @@ main = do
                   "(hi world hallo . welt)" ~=?
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world hallo)" ~=?
+                  pprintIt l3
+                ]
+
+              , TestLabel "pretty print width 10" $
+                let pprintIt = pprintSExpr 10 Swing in TestList
+                [ TestLabel "pretty print SNil" $ "()" ~=? pprintIt SNil
+                , TestLabel "pretty print SAtom" $ "hi" ~=? pprintIt (SAtom (AIdent "hi"))
+                , TestLabel "pretty print pair" $ "(hi . world)" ~=?
+                  pprintIt pair
+                , TestLabel "pretty print list of 1" $ "(hi)" ~=?
+                  pprintIt l1
+                , TestLabel "pretty print list of 2" $ "(hi world)" ~=?
+                  pprintIt l2
+                , TestLabel "pretty print list of 2 pairs" $
+                  "((hi . hallo) \n world . welt)" ~=?
+                  pprintIt l2p
+                , TestLabel "pretty print list of 3 ending in a pair" $
+                  "(hi \n world\n hallo . welt)" ~=?
+                  pprintIt l3ep
+                , TestLabel "pretty print list of 3" $ "(hi \n world\n hallo)" ~=?
                   pprintIt l3
                 ]
 

--- a/test/SCargotPrintParse.hs
+++ b/test/SCargotPrintParse.hs
@@ -34,6 +34,16 @@ main = do
                       (SCons
                         (SAtom (AIdent "world"))
                         (SAtom (AIdent "welt"))))
+              -- l3sp = list of 3 starting in a pair
+              l3sp = (SCons
+                       (SCons
+                         (SAtom (AIdent "hi"))
+                         (SAtom (AIdent "world")))
+                       (SCons
+                         (SAtom (AIdent "hallo"))
+                         (SCons
+                           (SAtom (AIdent "welt"))
+                           SNil)))
               -- l3ep = list of 3 ending in a pair
               l3ep = (SCons
                        (SAtom (AIdent "hi"))
@@ -50,6 +60,26 @@ main = do
                        (SCons
                          (SAtom (AIdent "hallo"))
                          SNil)))
+              -- l5p = list of 5 pairs
+              l5p = (SCons
+                      (SCons
+                        (SAtom (AIdent "hi"))
+                        (SAtom (AIdent "world")))
+                      (SCons
+                        (SCons
+                          (SAtom (AIdent "hallo"))
+                          (SAtom (AIdent "welt")))
+                        (SCons
+                          (SCons
+                            (SAtom (AIdent "bonjour"))
+                            (SAtom (AIdent "monde")))
+                          (SCons
+                            (SCons
+                              (SAtom (AIdent "hola"))
+                              (SAtom (AIdent "mundo")))
+                            (SCons
+                              (SAtom (AIdent "ciao"))
+                              (SAtom (AIdent "mundo")))))))
               -- l2 = list of 2
               l2 = (SCons
                      (SAtom (AIdent "hi"))
@@ -92,12 +122,19 @@ main = do
                   printSExpr l2
                 , TestLabel "flatprint list of 2 pairs" $ "((hi . hallo) world . welt)" ~=?
                   printSExpr l2p
+                , TestLabel "flatprint list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world) hallo welt)" ~=?
+                  printSExpr l3sp
                 , TestLabel "flatprint list of 3 ending in a pair" $ "(hi world hallo . welt)" ~=?
                   printSExpr l3ep
                 , TestLabel "flatprint list of 3" $ "(hi world hallo)" ~=?
                   printSExpr l3
                 , TestLabel "flatprint pair of list of 4" $ "(hi (world and people) hallo welt und leute)" ~=?
                   printSExpr linl
+                , TestLabel "flatprint list of 5 pairs" $
+                  "((hi . world) (hallo . welt) (bonjour . monde) (hola . mundo) ciao . mundo)" ~=?
+                  printSExpr l5p
                 ]
 
               , TestLabel "pretty print width 40" $
@@ -113,6 +150,10 @@ main = do
                 , TestLabel "pretty print list of 2 pairs" $
                   "((hi . hallo) world . welt)" ~=?
                   pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world) hallo welt)" ~=?
+                  pprintIt l3sp
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi world hallo . welt)" ~=?
                   pprintIt l3ep
@@ -120,6 +161,9 @@ main = do
                   pprintIt l3
                 , TestLabel "pretty print pair of list of 4" $ "(hi\n  (world and people)\n  hallo\n  welt\n  und\n  leute)" ~=?
                   pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world)\n  (hallo . welt)\n  (bonjour . monde)\n  (hola . mundo)\n  ciao . mundo)" ~=?
+                  pprintIt l5p
                 ]
 
               , TestLabel "pretty print width 10" $
@@ -135,6 +179,10 @@ main = do
                 , TestLabel "pretty print list of 2 pairs" $
                   "((hi . hallo)\n  world . welt)" ~=?
                   pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world)\n  hallo\n  welt)" ~=?
+                  pprintIt l3sp
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi\n  world\n  hallo . welt)" ~=?
                   pprintIt l3ep
@@ -142,6 +190,9 @@ main = do
                   pprintIt l3
                 , TestLabel "pretty print pair of list of 4" $ "(hi\n  (world\n    and\n    people)\n  hallo\n  welt\n  und\n  leute)" ~=?
                   pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world)\n  (hallo . welt)\n  (bonjour . monde)\n  (hola . mundo)\n  ciao . mundo)" ~=?
+                  pprintIt l5p
                 ]
 
               , TestLabel "pretty print width 10 swing-after 3" $
@@ -158,6 +209,10 @@ main = do
                   -- pairs are not split internally
                   "((hi . hallo) world . welt)" ~=?
                   pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world) hallo welt)" ~=?
+                  pprintIt l3sp
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   -- pairs are not split internally
                   "(hi world hallo . welt)" ~=?
@@ -168,6 +223,9 @@ main = do
                   -- atom list pair\n ...
                   "(hi (world and people) hallo welt\n  und\n  leute)" ~=?
                   pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world) (hallo . welt) (bonjour . monde) (hola . mundo)\n  ciao . mundo)" ~=?
+                  pprintIt l5p
                 ]
 
               , TestLabel "pretty print width 10 aligned" $
@@ -183,13 +241,21 @@ main = do
                 , TestLabel "pretty print list of 2 pairs" $
                   "((hi . hallo) world . welt)" ~=?
                   pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world) hallo\n              welt)" ~=?
+                  pprintIt l3sp
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi world\n    hallo . welt)" ~=?
                   pprintIt l3ep
                 , TestLabel "pretty print list of 3" $ "(hi world\n    hallo)" ~=?
                   pprintIt l3
-                , TestLabel "pretty print pair of list of 4" $ "(hi (world and\n           people)\n    hallo\n    welt\n    und\n    leute)" ~=?
+                , TestLabel "pretty print pair of list of 4" $
+                  "(hi (world and\n           people)\n    hallo\n    welt\n    und\n    leute)" ~=?
                   pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world) (hallo . welt)\n              (bonjour . monde)\n              (hola . mundo)\n              ciao . mundo)" ~=?
+                  pprintIt l5p
                 ]
 
               , TestLabel "unconstrained print" $
@@ -205,6 +271,10 @@ main = do
                 , TestLabel "pretty print list of 2 pairs" $
                   "((hi . hallo)\n world\n . welt)" ~=?
                   pprintIt l2p
+                , TestLabel "pretty print list of 3 starting in a pair" $
+                  -- pairs count as a single element
+                  "((hi . world)\n hallo\n welt)" ~=?
+                  pprintIt l3sp
                 , TestLabel "pretty print list of 3 ending in a pair" $
                   "(hi world hallo . welt)" ~=?
                   pprintIt l3ep
@@ -212,6 +282,9 @@ main = do
                   pprintIt l3
                 , TestLabel "pretty print pair of list of 4" $ "(hi\n (world and people)\n hallo\n welt\n und\n leute)" ~=?
                   pprintIt linl
+                , TestLabel "pretty print list of 5 pairs" $
+                  "((hi . world)\n (hallo . welt)\n (bonjour . monde)\n (hola . mundo)\n ciao\n . mundo)" ~=?
+                  pprintIt l5p
                 ]
 
               ]


### PR DESCRIPTION
Some of the updates in 0.1.5.0 caused various changes in the output like extra trailing spaces that didn't trigger local test failures but were detected downstream.

This PR adds tests for those and a number of other printing configurations.  It also provides various fixes for indentation and trailing whitespace, all of which are validated with full tests.